### PR TITLE
refactor: migrate to ESM, replace third-party modules with native alt…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+yarn.lock

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,11 @@
-module.exports = {
+export default {
+  preset: 'ts-jest/presets/default-esm',
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
-  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(t|j)s$',
-  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transformIgnorePatterns: [],
 };

--- a/package.json
+++ b/package.json
@@ -31,27 +31,26 @@
   "module": "lib/index.esm.js",
   "dependencies": {
     "checksum": "^1.0.0",
-    "graceful-fs": "^4.2.10",
     "md5": "^2.3.0",
-    "node-fetch": "^2.6.7",
     "typed-emitter": "^2.1.0",
-    "uuid": "^9.0.0"
+    "uuid": "^11.0.3"
   },
   "devDependencies": {
-    "@types/checksum": "^0.1.33",
-    "@types/jest": "29.2.4",
-    "@types/md5": "^2.3.2",
-    "@types/node-fetch": "^2.6.2",
-    "@typescript-eslint/eslint-plugin": "^5.46.1",
-    "@typescript-eslint/parser": "^5.46.1",
-    "eslint": "^8.30.0",
-    "eslint-plugin-jest": "^27.1.7",
-    "husky": "^8.0.2",
-    "jest": "^29.3.1",
-    "prettier": "2.8.1",
-    "ts-jest": "^29.0.3",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "@jest/types": "^29.6.3",
+    "@types/checksum": "^0.1.35",
+    "@types/jest": "29.5.14",
+    "@types/md5": "^2.3.5",
+    "@types/node": "^22.9.1",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
+    "eslint": "^9.15.0",
+    "eslint-plugin-jest": "^28.9.0",
+    "husky": "^9.1.7",
+    "jest": "^29.7.0",
+    "prettier": "3.3.3",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
   },
   "engines": {
     "node": ">=10"

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -1,10 +1,7 @@
-import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
-import fs from 'graceful-fs';
+import fs from 'node:fs/promises';
 import path from 'path';
+import { setTimeout as delay } from 'timers/promises';
 
-// Fetching
-const delay = (ms: number) =>
-  new Promise((resolve) => setTimeout(() => resolve(null), ms));
 
 export const retryFetch = (
   url: RequestInfo,
@@ -33,18 +30,18 @@ export const retryFetch = (
 // Download
 export async function downloadFile(file: string, url: string): Promise<void> {
   const dir = path.join(file, '..');
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(file, '');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(file, '');
   const res = await retryFetch(url);
-  const buffer = await res.buffer();
-  fs.writeFileSync(file, buffer);
+  const buffer = await res.arrayBuffer();
+  await fs.writeFile(file, Buffer.from(buffer));
 }
 
 export async function downloadFileIfNotExist(
   file: string,
   url: string | undefined,
 ): Promise<boolean> {
-  if (url && !fs.existsSync(file)) {
+  if (url && !fs.access(file)) {
     await downloadFile(file, url);
     return true;
   }

--- a/tests/check-installed.test.ts
+++ b/tests/check-installed.test.ts
@@ -16,5 +16,5 @@ test('Installation check', async () => {
   });
 
   await launcher.prepare();
-  expect(launcher.isDownloaded()).toBeDefined();
+  expect(await launcher.isDownloaded()).toBeDefined();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,20 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ESNext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
-    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "declarationMap": true, /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true, /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./lib" /* Redirect output structure to the directory. */,
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./src", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -23,7 +22,6 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -33,15 +31,13 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
     /* Additional Checks */
-    "noUnusedLocals": true,                /* Report errors on unused locals. */
-    "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
+    "noUnusedLocals": true, /* Report errors on unused locals. */
+    "noUnusedParameters": true, /* Report errors on unused parameters. */
+    "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -51,21 +47,24 @@
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "resolveJsonModule": true /* Include JSON files in the compilation and treat them as modules. */
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/__tests__/*"
+  ]
 }


### PR DESCRIPTION
### Cambios realizados
- Migración a módulos ESM.
- Reemplazo de dependencias de terceros (`graceful-fs` → `fs/promises`, eliminación de `node-fetch`).
- Actualización de dependencias a las últimas versiones.
- Implementación de funciones asincrónicas para operaciones con archivos.
